### PR TITLE
更新客户端版本号

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -27,14 +27,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - target: linux
-            host: ubuntu-latest
+          # - target: linux
+            # host: ubuntu-latest
           - target: windows
             host: windows-latest
-          - target: macos
-            host: macos-latest
-          - target: ios
-            host: macos-latest
+          # - target: macos
+            # host: macos-latest
+          # - target: ios
+            # host: macos-latest
           - target: android-arm64
             host: ubuntu-latest
 

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -31,10 +31,10 @@ jobs:
             host: ubuntu-latest
           - target: windows
             host: windows-latest
-          - target: macos
-            host: macos-latest
-          - target: ios
-            host: macos-latest
+          # - target: macos
+            # host: macos-latest
+          # - target: ios
+            # host: macos-latest
           - target: android-arm64
             host: ubuntu-latest
 

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -27,14 +27,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # - target: linux
-            # host: ubuntu-latest
+          - target: linux
+            host: ubuntu-latest
           - target: windows
             host: windows-latest
-          # - target: macos
-            # host: macos-latest
-          # - target: ios
-            # host: macos-latest
+          - target: macos
+            host: macos-latest
+          - target: ios
+            host: macos-latest
           - target: android-arm64
             host: ubuntu-latest
 

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -27,17 +27,17 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - target: linux
-            host: ubuntu-latest
+          # - target: linux
+            # host: ubuntu-latest
           - target: windows
             host: windows-latest
-          - target: macos
-            host: macos-latest
-          - target: ios
-            host: macos-latest
-          - target: android-arm64
-            host: ubuntu-latest
-
+          # - target: macos
+            # host: macos-latest
+          # - target: ios
+            # host: macos-latest
+          # - target: android-arm64
+            # host: ubuntu-latest
+            
     runs-on: ${{ matrix.config.host }}
 
     env:

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -31,10 +31,10 @@ jobs:
             host: ubuntu-latest
           - target: windows
             host: windows-latest
-          # - target: macos
-            # host: macos-latest
-          # - target: ios
-            # host: macos-latest
+          - target: macos
+            host: macos-latest
+          - target: ios
+            host: macos-latest
           - target: android-arm64
             host: ubuntu-latest
 

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -71,20 +71,20 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - target: linux
-            host: ubuntu-latest
+          # - target: linux
+            # host: ubuntu-latest
           - target: windows
             host: windows-latest
-          - target: macos
-            host: macos-latest
-          - target: ios
-            host: macos-latest
+          # - target: macos
+            # host: macos-latest
+          # - target: ios
+            # host: macos-latest
           - target: android-arm32
             host: ubuntu-latest
           - target: android-arm64
             host: ubuntu-latest
-          - target: android-x86_64
-            host: ubuntu-latest
+          # - target: android-x86_64
+            # host: ubuntu-latest
 
     runs-on: ${{ matrix.config.host }}
 

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -71,20 +71,20 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # - target: linux
-            # host: ubuntu-latest
+          - target: linux
+            host: ubuntu-latest
           - target: windows
             host: windows-latest
-          # - target: macos
-            # host: macos-latest
-          # - target: ios
-            # host: macos-latest
-          # - target: android-arm32
-            # host: ubuntu-latest
-          # - target: android-arm64
-            # host: ubuntu-latest
-          # - target: android-x86_64
-            # host: ubuntu-latest
+          - target: macos
+            host: macos-latest
+          - target: ios
+            host: macos-latest
+          - target: android-arm32
+            host: ubuntu-latest
+          - target: android-arm64
+            host: ubuntu-latest
+          - target: android-x86_64
+            host: ubuntu-latest
 
     runs-on: ${{ matrix.config.host }}
 

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -71,20 +71,20 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # - target: linux
-            # host: ubuntu-latest
+          - target: linux
+            host: ubuntu-latest
           - target: windows
             host: windows-latest
-          # - target: macos
-            # host: macos-latest
-          # - target: ios
-            # host: macos-latest
+          - target: macos
+            host: macos-latest
+          - target: ios
+            host: macos-latest
           - target: android-arm32
             host: ubuntu-latest
           - target: android-arm64
             host: ubuntu-latest
-          # - target: android-x86_64
-            # host: ubuntu-latest
+          - target: android-x86_64
+            host: ubuntu-latest
 
     runs-on: ${{ matrix.config.host }}
 

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -75,10 +75,10 @@ jobs:
             host: ubuntu-latest
           - target: windows
             host: windows-latest
-          - target: macos
-            host: macos-latest
-          - target: ios
-            host: macos-latest
+          # - target: macos
+          #   host: macos-latest
+          # - target: ios
+            # host: macos-latest
           - target: android-arm32
             host: ubuntu-latest
           - target: android-arm64

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -71,20 +71,20 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - target: linux
-            host: ubuntu-latest
+          # - target: linux
+            # host: ubuntu-latest
           - target: windows
             host: windows-latest
-          - target: macos
-            host: macos-latest
-          - target: ios
-            host: macos-latest
-          - target: android-arm32
-            host: ubuntu-latest
-          - target: android-arm64
-            host: ubuntu-latest
-          - target: android-x86_64
-            host: ubuntu-latest
+          # - target: macos
+            # host: macos-latest
+          # - target: ios
+            # host: macos-latest
+          # - target: android-arm32
+            # host: ubuntu-latest
+          # - target: android-arm64
+            # host: ubuntu-latest
+          # - target: android-x86_64
+            # host: ubuntu-latest
 
     runs-on: ${{ matrix.config.host }}
 

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -75,10 +75,10 @@ jobs:
             host: ubuntu-latest
           - target: windows
             host: windows-latest
-          # - target: macos
-          #   host: macos-latest
-          # - target: ios
-            # host: macos-latest
+          - target: macos
+            host: macos-latest
+          - target: ios
+            host: macos-latest
           - target: android-arm32
             host: ubuntu-latest
           - target: android-arm64

--- a/rust/src/copy_client/client.rs
+++ b/rust/src/copy_client/client.rs
@@ -67,11 +67,14 @@ impl Client {
                 "authorization",
                 format!("Token {}", self.get_token().await.as_str()),
             )
-            .header("referer", "com.copymanga.app-2.1.7")
-            .header("user-agent", "COPY/2.1.7")
+            // .header("referer", "com.copymanga.app-2.1.7")
+            .header("referer", "com.copymanga.app-2.2.0")
+            // .header("user-agent", "COPY/2.1.7")
+            .header("user-agent", "COPY/2.2.0")
             .header("source", "copyApp")
             .header("webp", "1")
-            .header("version", "2.1.7")
+            // .header("version", "2.1.7")
+            .header("version", "2.2.0")
             .header("region", "1")
             .header("platform", "3")
             .header("accept", "application/json")


### PR DESCRIPTION
在fork项目中测试Release除windows端外都可以使用，仅更改了`client.rs`中的版本信息。
<img width="636" alt="Snipaste_2024-06-03_17-16-42" src="https://github.com/niuhuan/kobi/assets/107249147/32afcd0f-f21c-4fdf-82ea-0b748b4f1478">

编译Realese/Windows-latest时仍有问题，`Check Assets`阶段报错：

```
error[E0793]: reference to packed field is unaligned
    --> C:\Users\runneradmin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\ntapi-0.3.7\src\ntexapi.rs:2783:52
     |
2783 |         *tick_count.QuadPart_mut() = read_volatile(&(*USER_SHARED_DATA).u.TickCountQuad);
     |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
     = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
     = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)

error[E0793]: reference to packed field is unaligned
    --> C:\Users\runneradmin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\ntapi-0.3.7\src\ntexapi.rs:2807:25
     |
2807 |         ((read_volatile(&(*USER_SHARED_DATA).u.TickCountQuad)
     |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
     = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
     = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)

   Compiling futures-task v0.3.21
For more information about this error, try `rustc --explain E0793`.
error: could not compile `ntapi` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 1.
```

`Cargo ci build cache`阶段报错：

```
Cache not found for input keys: Windows-cargo-ci_target
```

经检查，执行`Release.yml`和`Package.yml`均未能生成`Windows-cargo-ci_target`，报错
```
[warning] path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```